### PR TITLE
Remove dampingCoefficient and implement the behavior using dampingCoefficientVector + add tests

### DIFF
--- a/Sofa/Component/MechanicalLoad/src/sofa/component/mechanicalload/NodalLinearDampingForceField.h
+++ b/Sofa/Component/MechanicalLoad/src/sofa/component/mechanicalload/NodalLinearDampingForceField.h
@@ -47,17 +47,11 @@ public:
     /// Vector of velocity damping coefficients (by cinematic dof and by node)
     Data< VecDeriv > d_dampingCoefficients;
 
-    /// Node-constant and isotropic damping coefficient
-    Data< Real > d_dampingCoefficient;
-
 protected:
 
     NodalLinearDampingForceField();
 
-    sofa::core::objectmodel::ComponentState updateFromDampingCoefficientVector();
-    sofa::core::objectmodel::ComponentState updateFromSingleDampingCoefficient();
-
-    bool isConstantIsotropic;
+    sofa::core::objectmodel::ComponentState updateFromDampingCoefficients();
 
 public:
 

--- a/Sofa/Component/MechanicalLoad/src/sofa/component/mechanicalload/NodalLinearDampingForceField.h
+++ b/Sofa/Component/MechanicalLoad/src/sofa/component/mechanicalload/NodalLinearDampingForceField.h
@@ -45,7 +45,7 @@ public:
     typedef core::objectmodel::Data<VecDeriv> DataVecDeriv;
 
     /// Vector of velocity damping coefficients (by cinematic dof and by node)
-    Data< VecDeriv > d_dampingCoefficientVector;
+    Data< VecDeriv > d_dampingCoefficients;
 
     /// Node-constant and isotropic damping coefficient
     Data< Real > d_dampingCoefficient;
@@ -73,16 +73,17 @@ public:
     void buildDampingMatrix(core::behavior::DampingMatrix* matrix) override;
 
     SReal getPotentialEnergy(const core::MechanicalParams* params, const DataVecCoord& x) const override;
+
+    using Inherit::addKToMatrix;
 };
 
-
 #if !defined(SOFA_COMPONENT_FORCEFIELD_NODALLINEARDAMPINGFORCEFIELD_CPP)
-extern template class SOFA_COMPONENT_MECHANICALLOAD_API NodalLinearDampingForceField<defaulttype::Vec3Types>;
-extern template class SOFA_COMPONENT_MECHANICALLOAD_API NodalLinearDampingForceField<defaulttype::Vec2Types>;
 extern template class SOFA_COMPONENT_MECHANICALLOAD_API NodalLinearDampingForceField<defaulttype::Vec1Types>;
+extern template class SOFA_COMPONENT_MECHANICALLOAD_API NodalLinearDampingForceField<defaulttype::Vec2Types>;
+extern template class SOFA_COMPONENT_MECHANICALLOAD_API NodalLinearDampingForceField<defaulttype::Vec3Types>;
 extern template class SOFA_COMPONENT_MECHANICALLOAD_API NodalLinearDampingForceField<defaulttype::Vec6Types>;
-extern template class SOFA_COMPONENT_MECHANICALLOAD_API NodalLinearDampingForceField<defaulttype::Rigid3Types>;
 extern template class SOFA_COMPONENT_MECHANICALLOAD_API NodalLinearDampingForceField<defaulttype::Rigid2Types>;
+extern template class SOFA_COMPONENT_MECHANICALLOAD_API NodalLinearDampingForceField<defaulttype::Rigid3Types>;
 #endif
 
 } // namespace sofa::component::mechanicalload

--- a/Sofa/Component/MechanicalLoad/tests/CMakeLists.txt
+++ b/Sofa/Component/MechanicalLoad/tests/CMakeLists.txt
@@ -4,6 +4,7 @@ project(Sofa.Component.MechanicalLoad_test)
 
 set(SOURCE_FILES
     ConstantForceField_test.cpp
+    NodalLinearDampingForcefield_test.cpp
     PlaneForceField_test.cpp
     QuadPressureForceField_test.cpp
     SkeletalMotionConstraint_test.cpp

--- a/Sofa/Component/MechanicalLoad/tests/NodalLinearDampingForcefield_test.cpp
+++ b/Sofa/Component/MechanicalLoad/tests/NodalLinearDampingForcefield_test.cpp
@@ -1,0 +1,160 @@
+/******************************************************************************
+*                 SOFA, Simulation Open-Framework Architecture                *
+*                    (c) 2006 INRIA, USTL, UJF, CNRS, MGH                     *
+*                                                                             *
+* This program is free software; you can redistribute it and/or modify it     *
+* under the terms of the GNU Lesser General Public License as published by    *
+* the Free Software Foundation; either version 2.1 of the License, or (at     *
+* your option) any later version.                                             *
+*                                                                             *
+* This program is distributed in the hope that it will be useful, but WITHOUT *
+* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or       *
+* FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License *
+* for more details.                                                           *
+*                                                                             *
+* You should have received a copy of the GNU Lesser General Public License    *
+* along with this program. If not, see <http://www.gnu.org/licenses/>.        *
+*******************************************************************************
+* Authors: The SOFA Team and external contributors (see Authors.txt)          *
+*                                                                             *
+* Contact information: contact@sofa-framework.org                             *
+******************************************************************************/
+
+//Force field
+#include <sofa/component/mechanicalload/NodalLinearDampingForceField.h>
+#include <sofa/component/solidmechanics/testing/ForceFieldTestCreation.h>
+
+namespace sofa {
+
+using sofa::component::mechanicalload::NodalLinearDampingForceField;
+
+template<class T>
+class MyNodalDamping : public NodalLinearDampingForceField<T> {
+public:
+    using NodalLinearDampingForceField<T>::d_dampingCoefficients;
+};
+
+/**  Test TrianglePressureForceField.
+  */
+template <typename _NodalLinearDampingForceField>
+struct NodalLinearDampingForceField_test : public ForceField_test<_NodalLinearDampingForceField>
+{
+    typedef ForceField_test<_NodalLinearDampingForceField> Inherited;
+    typedef _NodalLinearDampingForceField ForceType;
+    typedef typename ForceType::DataTypes DataTypes;
+
+    typedef typename ForceType::VecCoord VecCoord;
+    typedef typename ForceType::VecDeriv VecDeriv;
+    typedef typename ForceType::Coord Coord;
+    typedef typename ForceType::Deriv Deriv;
+    typedef typename Coord::value_type Real;
+    typedef type::Vec<3,Real> Vec3;
+
+    VecCoord x;
+    VecDeriv v,f;
+
+    NodalLinearDampingForceField_test():
+        Inherited::ForceField_test(std::string(SOFA_COMPONENT_MECHANICALLOAD_TEST_SCENES_DIR) + "/" + "NodalLinearDampingForceField.scn")
+    {
+//        // potential energy is not implemented and won't be tested
+//        //this->flags &= ~Inherited::TEST_POTENTIAL_ENERGY;
+
+//        // Set vectors, using DataTypes::set to cope with tests in dimension 2
+//        //Position
+//        x.resize(3);
+//        DataTypes::set( x[0], 0,0,0);
+//        DataTypes::set( x[1], 1,0,0);
+//        DataTypes::set( x[2], 1,1,0);
+
+//        //Velocity
+//        v.resize(3);
+//        DataTypes::set( v[0], 0,0,0);
+//        DataTypes::set( v[1], 0,0,0);
+//        DataTypes::set( v[2], 0,0,0);
+
+//        //Force
+//        f.resize(3);
+//        Vec3 f0(0,0,0.1);
+//        DataTypes::set( f[0],  f0[0], f0[1], f0[2]);
+//        DataTypes::set( f[1],  f0[0], f0[1], f0[2]);
+//        DataTypes::set( f[2],  f0[0], f0[1], f0[2]);
+
+//        // Set the properties of the force field
+//        sofa::type::vector<Index> indices = {0};
+//        Inherited::force->d_triangleList.setValue(indices);
+//        Inherited::force->d_pressure=Coord(0,0,0.6);
+    }
+
+    void test_requiredInputs()
+    {
+        EXPECT_MSG_EMIT(Error);
+        sofa::simulation::node::initRoot(Inherited::node.get());
+        ASSERT_FALSE(this->force->isComponentStateValid());
+    }
+
+    void test_setCoeficientsSizeSameAsMState()
+    {
+        this->force->findData("dampingCoefficient")->read("1.0");
+        sofa::simulation::node::initRoot(Inherited::node.get());
+
+        ASSERT_TRUE(this->force->isComponentStateValid());
+        ASSERT_EQ(this->dof->getSize(), this->force->d_dampingCoefficients.getValue().size());
+    }
+
+    void test_setConstantDamping()
+    {
+        this->force->findData("dampingCoefficient")->read("1.0");
+        this->force->init();
+
+        type::vector<Vec3> ones = {{1.0,1.0,1.0}};
+        type::vector<Vec3> res = this->force->d_dampingCoefficients.getValue();
+        ASSERT_EQ(res, ones);
+    }
+
+    void test_valueForce()
+    {
+        // run the forcefield_test
+        Inherited::run_test( x, v, f );
+    }
+
+    // Test that the force value is constant
+    void test_constantForce()
+    {
+        sofa::simulation::node::initRoot(Inherited::node.get());
+
+        // Do a few animation steps
+        for(int k=0;k<10;k++)
+        {
+            sofa::simulation::node::animate(Inherited::node.get(), 0.5_sreal);
+        }
+
+        // run the forcefield_test
+        Inherited::run_test( x, v, f, false );
+    }
+};
+
+// Types to instantiate.
+typedef ::testing::Types<
+    MyNodalDamping<defaulttype::Vec3Types>
+> TestTypes;
+
+
+// Tests to run for each instantiated type
+TYPED_TEST_SUITE(NodalLinearDampingForceField_test, TestTypes);
+
+TYPED_TEST( NodalLinearDampingForceField_test , requiredInput)
+{
+    this->test_requiredInputs();
+}
+
+TYPED_TEST( NodalLinearDampingForceField_test , setDamping)
+{
+    this->test_setConstantDamping();
+}
+
+TYPED_TEST( NodalLinearDampingForceField_test , setCoeficientsSizeSameAsMState)
+{
+    this->test_setCoeficientsSizeSameAsMState();
+}
+
+}// namespace sofa

--- a/Sofa/Component/MechanicalLoad/tests/scenes/NodalLinearDampingForceField.scn
+++ b/Sofa/Component/MechanicalLoad/tests/scenes/NodalLinearDampingForceField.scn
@@ -1,0 +1,14 @@
+<?xml version="1.0"?>
+
+<Node 	name="Root" gravity="0 0 0" time="0" animate="0"  dt="0.5" showAxis="true">
+    <RequiredPlugin name="Sofa.Component.StateContainer"/> <!-- Needed to use components [MechanicalObject] -->
+    <RequiredPlugin name="Sofa.Component.Topology.Container.Constant"/> <!-- Needed to use components [MeshTopology] -->
+    <RequiredPlugin name="Sofa.Component.Topology.Container.Dynamic"/> <!-- Needed to use components [TriangleSetGeometryAlgorithms TriangleSetTopologyContainer TriangleSetTopologyModifier] -->
+
+    <DefaultAnimationLoop />
+
+    <MechanicalObject name="DOFs" showObject="1"  showObjectScale="5"  showIndices="1"  showIndicesScale="0.0003" position="0 0 0 1 0 0 0 1 0" />
+
+    <!--<NodalLinearDampingForceField/>-->
+
+</Node>

--- a/examples/Component/SolidMechanics/FEM/DampingForceField.scn
+++ b/examples/Component/SolidMechanics/FEM/DampingForceField.scn
@@ -23,15 +23,22 @@
     <Node name="isotropic (green)"  >
         <MechanicalObject template="Vec3" name="mObject2"  position="0 0 0"  velocity="1 1 1"  force="0 0 0"  externalForce="0 0 0"  derivX="0 0 0"  restScale="1"  showObject="1"  showObjectScale="0.1"  drawMode="3" />
         <UniformMass name="uniformMass3" totalMass="1.0"/>
-        <NodalLinearDampingForceField template="Vec3" name="uniformVelocityDampingFF0" dampingCoefficient="0.5" />
+        <NodalLinearDampingForceField template="Vec3" name="uniformVelocityDampingFF0" dampingCoefficients="0.5 0.5 0.5"/>
         <TrailRenderer template="Vec3" position="@mObject2.position" color="0 1 0 1"/>
     </Node>
 
     <Node name="anisotropic (red)"  >
         <MechanicalObject template="Vec3" name="mObject3"  position="0 0 0"  velocity="1 1 1"  force="0 0 0"  externalForce="0 0 0"  derivX="0 0 0"  restScale="1"  showObject="1"  drawMode="2" />
         <UniformMass name="uniformMass3" totalMass="1.0"/>
-        <NodalLinearDampingForceField template="Vec3" name="diagonalVelocityDampingFF1"  dampingCoefficientVector="0.5 0.2 0.2" />
+        <NodalLinearDampingForceField template="Vec3" name="diagonalVelocityDampingFF1"  dampingCoefficients="0.5 0.2 0.2" />
         <TrailRenderer template="Vec3" position="@mObject3.position" color="1 0 0 1"/>
+    </Node>
+
+    <Node name="anisotropic multi (blue)"  >
+        <MechanicalObject template="Vec3" name="mObject3"  position="-1 0 0 1 0 0"  velocity="1 1 1 1 1 1"  force="0 0 0 0 0 0"  externalForce="0 0 0 0 0 0"  derivX="0 0 0 0 0 0"  restScale="1"  showObject="1"  drawMode="4" showColor="0 0 1"/>
+        <UniformMass name="uniformMass3" totalMass="1.0"/>
+        <NodalLinearDampingForceField template="Vec3" name="diagonalVelocityDampingFF1"  dampingCoefficients="0.5 0.2 0.2" />
+        <TrailRenderer template="Vec3" position="@mObject3.position" color="0 0 1 1"/>
     </Node>
 
 </Node>


### PR DESCRIPTION
It was not mentioned in initial PR the decision about having dampingCoefficientVector and dampingCoefficient. 
Given the co-existence of these two data, it is questionable to keep both. 
In this PR is removed dampingCoefficient implementing the same behavior through dampingCoefficientVector

The resulting code is much shorter and simpler. 


______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
